### PR TITLE
[FEAT] 로그인 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -33,8 +36,19 @@ dependencies {
 
     implementation 'org.flywaydb:flyway-core:9.8.1'
     implementation 'org.flywaydb:flyway-mysql:9.8.1'
+
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.security:spring-security-test'
+
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+bootJar{
+    archivesBaseName = 'wanted'
+    archiveFileName = 'wanted.jar'
+    archiveVersion = "0.0.1"
 }

--- a/src/main/java/com/onboarding/wanted/config/security/CustomAuthenticationFilter.java
+++ b/src/main/java/com/onboarding/wanted/config/security/CustomAuthenticationFilter.java
@@ -1,0 +1,43 @@
+package com.onboarding.wanted.config.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onboarding.wanted.config.security.exception.FailLoginRequestException;
+import com.onboarding.wanted.member.web.dto.SignInRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+
+@RequiredArgsConstructor
+@Slf4j
+public class CustomAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+    private final AuthenticationManager authenticationManager;
+
+    /**
+     * 로그인 요청 시
+     * CustomAthenticationFilter가 동작하여 AuthenticationToken을 생성하고
+     * 이를 AuthenticationManager에게 인증 요청
+     */
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) {
+        SignInRequest loginDto;
+        try {
+            loginDto = new ObjectMapper().readValue(request.getInputStream(), SignInRequest.class);
+        } catch (IOException e) {
+            throw new FailLoginRequestException();
+        }
+        String username = loginDto.getEmail();
+        String password = loginDto.getPassword();
+
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(username, password);
+
+        return authenticationManager.authenticate(token);
+    }
+}

--- a/src/main/java/com/onboarding/wanted/config/security/CustomAuthenticationProvider.java
+++ b/src/main/java/com/onboarding/wanted/config/security/CustomAuthenticationProvider.java
@@ -1,0 +1,50 @@
+package com.onboarding.wanted.config.security;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component("authenticationProvider")
+@RequiredArgsConstructor
+@Slf4j
+public class CustomAuthenticationProvider implements AuthenticationProvider {
+    private final PasswordEncoder passwordEncoder;
+    private final CustomUserDetailsService domainUserDetailsService;
+
+    /**
+     * AuthenticationManager가 넘겨준 Authentication 객체를 통해
+     * DB 내 username/password 비교를 통해 인증한다.
+     * 이후, 성공시 Authentication 객체 반환
+     */
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        String inputEmail = authentication.getName();
+        String inputPassword = (String) authentication.getCredentials();
+
+        UserDetails userDetails = domainUserDetailsService.loadUserByUsername(inputEmail);
+
+        if (isNotMatches(inputPassword, userDetails.getPassword())) {
+            throw new BadCredentialsException(inputEmail);
+        }
+        return new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(), userDetails.getAuthorities());
+    }
+
+    /**
+     * AuthenticationProvider에 표시된 Authentication 객체를 지원하는지 여부를 반환
+     */
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return authentication.equals(UsernamePasswordAuthenticationToken.class);
+    }
+
+    private boolean isNotMatches(String password, String encodedPassword) {
+        return !passwordEncoder.matches(password, encodedPassword);
+    }
+}

--- a/src/main/java/com/onboarding/wanted/config/security/CustomTokenProvider.java
+++ b/src/main/java/com/onboarding/wanted/config/security/CustomTokenProvider.java
@@ -1,0 +1,84 @@
+package com.onboarding.wanted.config.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.onboarding.wanted.config.security.JwtConstants.*;
+import static com.onboarding.wanted.config.security.JwtConstants.REFRESH_TOKEN_VALIDATION_SECOND;
+
+@Component
+@RequiredArgsConstructor
+public class CustomTokenProvider {
+    @Value("{jwt.secret.key}")
+    private String SECRET_KEY;
+
+    public String generateAccessToken(CustomUserDetail member) {
+        return Jwts.builder()
+                .setHeader(createHeader())
+                .setClaims(createClaims(member))
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_VALIDATION_SECOND))
+                .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
+                .compact();
+    }
+
+    public String generateRefreshToken(CustomUserDetail member) {
+        return Jwts.builder()
+                .setHeader(createHeader())
+                .setClaims(createClaims(member))
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_VALIDATION_SECOND))
+                .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
+                .compact();
+    }
+
+    private Map<String, Object> createHeader() {
+        HashMap<String, Object> header = new HashMap<>();
+        header.put("typ", "JWT");
+        header.put("alg", "HS256");
+        return header;
+    }
+
+    private Claims createClaims(CustomUserDetail member) {
+        Claims claims = Jwts.claims();
+        claims.put("username", member.getUsername());
+        claims.put("roles", member.getAuthorities());
+
+        return claims;
+    }
+
+    public boolean validateToken(String token, UserDetails userDetails) {
+        String username = getUsername(token);
+        return username.equals(userDetails.getUsername()) && !isTokenExpired(token);
+    }
+
+    private String getUsername(String token) {
+        return extractAllClaims(token).get("username", String.class);
+    }
+
+    private Claims extractAllClaims(String token) {
+        return Jwts.parser()
+                .setSigningKey(getSigningKey(SECRET_KEY))
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    private byte[] getSigningKey(String secretKey) {
+        return secretKey.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private boolean isTokenExpired(String token) {
+        Date expiration = extractAllClaims(token).getExpiration();
+        return expiration.before(new Date());
+    }
+}

--- a/src/main/java/com/onboarding/wanted/config/security/CustomUserDetail.java
+++ b/src/main/java/com/onboarding/wanted/config/security/CustomUserDetail.java
@@ -1,0 +1,70 @@
+package com.onboarding.wanted.config.security;
+
+import com.onboarding.wanted.member.entity.MemberEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CustomUserDetail implements UserDetails {
+    private final transient MemberEntity member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(member.getRole().toString()));
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+
+    /**
+     *
+     * @return 계정 만료 상태(true : 만료되지 않음)
+     */
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    /**
+     *
+     * @return 계정 잠금 상태(true : 잠기지 않음)
+     */
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    /**
+     *
+     * @return 계정 활성화(사용 가능) 상태 (true : 활성화)
+     */
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    /**
+     *
+     * @return 계정의 권한 목록
+     */
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+}

--- a/src/main/java/com/onboarding/wanted/config/security/CustomUserDetailsService.java
+++ b/src/main/java/com/onboarding/wanted/config/security/CustomUserDetailsService.java
@@ -1,0 +1,24 @@
+package com.onboarding.wanted.config.security;
+
+import com.onboarding.wanted.member.domain.service.MemberRepository;
+import com.onboarding.wanted.member.entity.MemberEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+    private static final String NOT_FOUND_EMAIL = "Cannot find email";
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        MemberEntity memberEntity = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException(NOT_FOUND_EMAIL));
+
+        return new CustomUserDetail(memberEntity);
+    }
+}

--- a/src/main/java/com/onboarding/wanted/config/security/JwtConstants.java
+++ b/src/main/java/com/onboarding/wanted/config/security/JwtConstants.java
@@ -1,0 +1,12 @@
+package com.onboarding.wanted.config.security;
+public final class JwtConstants {
+    public static final Long ACCESS_TOKEN_VALIDATION_SECOND = 1800L * 1000;
+    public static final Long REFRESH_TOKEN_VALIDATION_SECOND = 1000L * 60 * 24 * 2;
+
+    public static final String BEARER = "Bearer ";
+    public static final String REFRESH_TOKEN = "refreshToken";
+
+    public static final String SIGNUP_URL = "api/signup";
+    public static final String LOGIN_URL = "/api/login";
+    public static final String REFRESH_URL = "/api/refresh";
+}

--- a/src/main/java/com/onboarding/wanted/config/security/SecurityConfig.java
+++ b/src/main/java/com/onboarding/wanted/config/security/SecurityConfig.java
@@ -1,0 +1,74 @@
+package com.onboarding.wanted.config.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import static com.onboarding.wanted.config.security.JwtConstants.*;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final AuthenticationFailureHandler authenticationFailureHandler;
+    private final AuthenticationSuccessHandler authenticationSuccessHandler;
+    private final AuthenticationConfiguration authenticationConfiguration;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager() throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        CustomAuthenticationFilter customAuthenticationFilter = new CustomAuthenticationFilter(authenticationManager());
+        customAuthenticationFilter.setFilterProcessesUrl(LOGIN_URL);
+        customAuthenticationFilter.setAuthenticationFailureHandler(authenticationFailureHandler);
+        customAuthenticationFilter.setAuthenticationSuccessHandler(authenticationSuccessHandler);
+
+        http.csrf().disable();
+        http.headers().frameOptions().sameOrigin();
+        http.cors().configurationSource(configurationSource());
+        http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+        http.formLogin().disable();
+        http.httpBasic().disable();
+        http.authorizeRequests().antMatchers(SIGNUP_URL + "/**", LOGIN_URL + "/**", REFRESH_URL + "/**").permitAll();
+
+        http.authorizeRequests().anyRequest().authenticated();
+        http.addFilter(customAuthenticationFilter);
+        http.addFilterBefore(customAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    private CorsConfigurationSource configurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*");
+        configuration.addAllowedOriginPattern("*");
+        configuration.setAllowCredentials(true);
+        configuration.addExposedHeader("Authorization");
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}
+

--- a/src/main/java/com/onboarding/wanted/config/security/exception/AuthErrorCode.java
+++ b/src/main/java/com/onboarding/wanted/config/security/exception/AuthErrorCode.java
@@ -1,0 +1,25 @@
+package com.onboarding.wanted.config.security.exception;
+
+import com.onboarding.wanted.common.errors.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum AuthErrorCode implements ErrorCode {
+    FAIL_LOGIN_REQUEST(HttpStatus.BAD_REQUEST, "로그인 요청 필드명이 옳지 않습니다.");
+    private final HttpStatus status;
+    private final String message;
+
+    AuthErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/onboarding/wanted/config/security/exception/FailLoginRequestException.java
+++ b/src/main/java/com/onboarding/wanted/config/security/exception/FailLoginRequestException.java
@@ -1,0 +1,10 @@
+package com.onboarding.wanted.config.security.exception;
+
+import com.onboarding.wanted.common.errors.exception.BusinessException;
+
+
+public final class FailLoginRequestException extends BusinessException {
+    public FailLoginRequestException() {
+        super(AuthErrorCode.FAIL_LOGIN_REQUEST);
+    }
+}

--- a/src/main/java/com/onboarding/wanted/config/security/handler/LoginFailureHandler.java
+++ b/src/main/java/com/onboarding/wanted/config/security/handler/LoginFailureHandler.java
@@ -1,0 +1,28 @@
+package com.onboarding.wanted.config.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onboarding.wanted.common.util.ApiResult;
+import com.onboarding.wanted.common.util.ResponseBody;
+import com.onboarding.wanted.common.util.ResponseGenerator;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class LoginFailureHandler implements AuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException{
+        response.setStatus(HttpServletResponse.SC_HTTP_VERSION_NOT_SUPPORTED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("utf-8");
+
+        ApiResult<ResponseBody.FailBody> result = ResponseGenerator.fail(HttpStatus.BAD_REQUEST, "ID 혹은 비밀번호가 일치하지 않습니다");
+        new ObjectMapper().writeValue(response.getWriter(), result.getBody());
+    }
+}

--- a/src/main/java/com/onboarding/wanted/config/security/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/onboarding/wanted/config/security/handler/LoginSuccessHandler.java
@@ -1,0 +1,56 @@
+package com.onboarding.wanted.config.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onboarding.wanted.common.util.ResponseBody;
+import com.onboarding.wanted.config.security.CustomTokenProvider;
+import com.onboarding.wanted.config.security.CustomUserDetail;
+import com.onboarding.wanted.member.domain.service.CreateTokenUsecase;
+import com.onboarding.wanted.util.CookieUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static com.onboarding.wanted.config.security.JwtConstants.*;
+import static com.onboarding.wanted.config.security.JwtConstants.REFRESH_TOKEN;
+
+@Component
+@RequiredArgsConstructor
+public class LoginSuccessHandler implements AuthenticationSuccessHandler {
+    private final CustomTokenProvider tokenProvider;
+    private final CreateTokenUsecase tokenUsecase;
+
+    /**
+     * 로그인 성공시 CustomSucessHandler가 동작
+     * 즉, AT 및 RT 생성 후 response에 반환
+     */
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+        CustomUserDetail member = (CustomUserDetail) authentication.getPrincipal();
+
+        String accessToken = tokenProvider.generateAccessToken(member);
+        String refreshToken = tokenProvider.generateRefreshToken(member);
+
+        tokenUsecase.execute(member.getUsername(), refreshToken);
+
+        Cookie cookie = CookieUtil.createCookie(REFRESH_TOKEN, refreshToken);
+
+        response.addHeader(HttpHeaders.AUTHORIZATION, BEARER + accessToken);
+        response.addCookie(cookie);
+        response.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+
+        ResponseBody.SuccessBodyWithoutData body = new ResponseBody.SuccessBodyWithoutData(HttpStatus.OK.toString());
+        ObjectMapper om = new ObjectMapper();
+        String responseBody = om.writeValueAsString(body);
+        response.getWriter().println(responseBody);
+    }
+}

--- a/src/main/java/com/onboarding/wanted/member/domain/service/CreateTokenUsecase.java
+++ b/src/main/java/com/onboarding/wanted/member/domain/service/CreateTokenUsecase.java
@@ -1,0 +1,17 @@
+package com.onboarding.wanted.member.domain.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CreateTokenUsecase {
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void execute(String email, String refreshToken) {
+        memberRepository.findByEmail(email)
+                .ifPresent(memberEntity -> memberEntity.updateRefreshToken(refreshToken));
+    }
+}

--- a/src/main/java/com/onboarding/wanted/member/web/dto/SignInRequest.java
+++ b/src/main/java/com/onboarding/wanted/member/web/dto/SignInRequest.java
@@ -1,0 +1,23 @@
+package com.onboarding.wanted.member.web.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.Min;
+
+@Getter
+@NoArgsConstructor
+public class SignInRequest {
+    @Email
+    private String email;
+    @Min(value = 8)
+    private String password;
+
+    @Builder
+    private SignInRequest(final String email, final String password) {
+        this.email = email;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/onboarding/wanted/util/CookieUtil.java
+++ b/src/main/java/com/onboarding/wanted/util/CookieUtil.java
@@ -1,0 +1,30 @@
+package com.onboarding.wanted.util;
+
+import lombok.experimental.UtilityClass;
+
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+import static com.onboarding.wanted.config.security.JwtConstants.*;
+
+@UtilityClass
+public class CookieUtil {
+    public Cookie createCookie(String cookieName, String value){
+        Cookie token = new Cookie(cookieName, value);
+        token.setHttpOnly(true);
+        token.setMaxAge(Math.toIntExact(REFRESH_TOKEN_VALIDATION_SECOND));
+        token.setPath("/");
+        return token;
+    }
+
+    public Cookie getCookie(HttpServletRequest req, String cookieName){
+        final Cookie[] cookies = req.getCookies();
+        if(cookies == null) return null;
+        for(Cookie cookie : cookies){
+            if(cookie.getName().equals(cookieName))
+                return cookie;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Security를 사용한 로그인 로직 처리(공부용이므로 추후 AOP를 사용하여 변경 예정)

- [x] 아이디,비밀번호 맞지 않을시 예외 처리
- [x] login request가 올바르지 않을 시 예외 처리
- [x] login 성공 시 refresh token은 cookie, access token은 header에 담아서 전달